### PR TITLE
Support launching as non-root user

### DIFF
--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -6,12 +6,12 @@ if [[ -z ${TF_RUNNER_VERSION} ]]; then
     TF_RUNNER_VERSION="0.12"
 fi
 
-TF_ARCHIVE=$(find ${TF_ARCHIVE_STORE} -name "terraform_${TF_RUNNER_VERSION}*.zip" -print)
+TF_ARCHIVE=$(find ${TF_ROOT_PATH} -name "terraform_${TF_RUNNER_VERSION}*.zip" -print)
 if [[ ${TF_ARCHIVE} == "" ]]; then
   log-output error "Unsupported terraform version: ${TF_RUNNER_VERSION}"
   exit 1
 fi
 
-unzip -q ${TF_ARCHIVE} -d /usr/local/bin/
+unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/
 
-/usr/bin/run-terraform $@
+/usr/bin/run-terraform "$@"

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -12,6 +12,10 @@ if [[ ${TF_ARCHIVE} == "" ]]; then
   exit 1
 fi
 
-unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/
-
-/usr/bin/run-terraform "$@"
+if [[ $UID -ne 0 ]]; then
+  sudo -E unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/
+  sudo -E /usr/bin/run-terraform "$@"
+else
+  unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/
+  /usr/bin/run-terraform "$@"
+fi

--- a/resources/tf_install.sh
+++ b/resources/tf_install.sh
@@ -3,7 +3,7 @@
 set -e
 
 VERSIONS=$1
-TF_ARCHIVE_STORE=$2
+TF_ROOT_PATH=$2
 RELEASE_URL="https://releases.hashicorp.com/terraform"
 RELEASE_HTML=$(echo | curl -s "${RELEASE_URL}" 2>/dev/null)
 
@@ -33,6 +33,6 @@ for VERSION in $VERSIONS; do
         exit 1
     fi
 
-    mv ${TF_ARCHIVE_FILE} ${TF_ARCHIVE_STORE}/
+    mv ${TF_ARCHIVE_FILE} ${TF_ROOT_PATH}/
     rm ${TF_SHASUMS_FILE}
 done

--- a/resources/tfrunner.sudoers
+++ b/resources/tfrunner.sudoers
@@ -1,0 +1,1 @@
+tfrunner ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
Added support to launch the container as a non-root user (E.g. when running on Windows / WSL2)
* Create new `tfrunner` user with UID `1000`
* Updated install path for `aws` CLI to `/usr/bin`
* Install `sudo` package
* Update entrypoint script to use sudo if not run as root
* Updated build arg and env variable names