### PR TITLE
Copy Terraform source directory for non-root user

### DIFF
--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -16,7 +16,9 @@ if [[ $UID -ne 0 ]]; then
     sudo unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/
     sudo cp -aR /root/.aws /home/tfrunner/.aws
     sudo cp -aR /root/.ssh /home/tfrunner/.ssh
-    sudo chown -R tfrunner:tfrunner /home/tfrunner/ /src
+    sudo cp -aR /src /home/tfrunner/src
+    sudo chown -R tfrunner:tfrunner /home/tfrunner/
+    pushd /home/tfrunner/src > /dev/null
 else
     unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/
 fi


### PR DESCRIPTION
Copy Terraform source code from `/src` when running as the non-root user to avoid clobbering local ownership