### PR TITLE
Install / use rsync to prepare terraform environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN yum install -y \
     git \
     jq \
     openssl \
+    rsync \
     sha256sum \
     sudo \
     unzip \

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -13,10 +13,11 @@ if [[ ${TF_ARCHIVE} == "" ]]; then
 fi
 
 if [[ $UID -ne 0 ]]; then
+    log-output info "Preparing terraform environment"
     sudo unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/
-    sudo cp -aR /root/.aws /home/tfrunner/.aws
-    sudo cp -aR /root/.ssh /home/tfrunner/.ssh
-    sudo cp -aR /src /home/tfrunner/src
+    sudo rsync -qa /root/.aws /home/tfrunner/
+    sudo rsync -qa /root/.ssh /home/tfrunner/
+    sudo rsync -qa --exclude '.terraform' /src /home/tfrunner/
     sudo chown -R tfrunner:tfrunner /home/tfrunner/
     pushd /home/tfrunner/src > /dev/null
 else


### PR DESCRIPTION
Installs and uses rsync to prepare the Terraform environment which gives us the ability to explicitly exclude any local `.terraform` directories
- These directories can be large and so can hugely slow down environment prep
- Including these directories can lead to state permission errors when running against multiple profiles/environment