### PR TITLE
Add Sync-Back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,5 +66,6 @@ RUN yum -y erase \
     rm -f /tf_install.sh
 
 WORKDIR /terraform-code
+USER tfrunner
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -12,20 +12,39 @@ if [[ ${TF_ARCHIVE} == "" ]]; then
     exit 1
 fi
 
-if [[ $UID -ne 0 ]]; then
-    log-output info "Preparing terraform environment"
-    sudo unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/
-    sudo rsync -qa /root/.aws /home/tfrunner/
-    sudo rsync -qa /root/.ssh /home/tfrunner/
-    sudo rsync -qa --exclude '.terraform' /src /home/tfrunner/
-    sudo chown -R tfrunner:tfrunner /home/tfrunner/
-    pushd /home/tfrunner/src > /dev/null
-else
-    unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/
+rsync_ignore_lock_opts=""
+if [[ -n "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" ]] && [[ "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" != "false" ]]; then
+    log-output info "Ignoring dependency lock file"
+    rsync_ignore_lock_opts="--exclude '.terraform.lock.hcl'"
 fi
+
+log-output info "Preparing terraform environment"
+
+unzip_command="sudo unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/ terraform"
+log-output debug "Running unzip command: ${unzip_command}"
+eval "${unzip_command}"
+
+rsync_aws_command="sudo rsync -qa /root/.aws /home/tfrunner/"
+log-output debug "Running rsync command: ${rsync_aws_command}"
+eval "${rsync_aws_command}"
+
+rsync_ssh_command="sudo rsync -qa /root/.ssh /home/tfrunner/"
+log-output debug "Running rsync command: ${rsync_ssh_command}"
+eval "${rsync_ssh_command}"
+
+rsync_src_command="sudo rsync -qa --exclude '.terraform' ${rsync_ignore_lock_opts} /src /home/tfrunner/"
+log-output debug "Running rsync command: ${rsync_src_command}"
+eval "${rsync_src_command}"
+
+sudo chown -R tfrunner:tfrunner /home/tfrunner/
+pushd /home/tfrunner/src > /dev/null
+
+log-output debug "Passing operation to run-terraform"
 /usr/bin/run-terraform "$@"
 
-if [[ -n "${USER_UID}" ]] && [[ -n "${USER_GID}" ]]; then
-    log-output info "Syncing pending changes back to user"
-    sudo rsync -qa --chown=${USER_UID}:${USER_GID} --exclude '.git/' --exclude '.terraform/'  ./ /src
+if [[ -z $TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE ]] || [[ "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" == "false" ]]; then
+    if [[ -n "${USER_UID}" ]] && [[ -n "${USER_GID}" ]]; then
+        log-output info "Syncing pending changes back to user"
+        sudo rsync -qa --chown=${USER_UID}:${USER_GID} --exclude '.git/' --exclude '.terraform/'  ./ /src
+    fi
 fi

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -44,7 +44,8 @@ log-output debug "Passing operation to run-terraform"
 
 if [[ -z $TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE ]] || [[ "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" == "false" ]]; then
     if [[ -n "${USER_UID}" ]] && [[ -n "${USER_GID}" ]]; then
+        rsync_sync_back_command="sudo rsync -qa --chown=${USER_UID}:${USER_GID} --exclude '.git/' --exclude '.terraform/'  ./ /src"
         log-output info "Syncing pending changes back to user"
-        sudo rsync -qa --chown=${USER_UID}:${USER_GID} --exclude '.git/' --exclude '.terraform/'  ./ /src
+        eval "${rsync_sync_back_command}"
     fi
 fi

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -14,7 +14,7 @@ fi
 
 rsync_ignore_lock_opts=""
 if [[ -n "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" ]] && [[ "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" != "false" ]]; then
-    log-output info "Ignoring dependency lock file"
+    log-output debug "Excluding dependency lock file from rsync"
     rsync_ignore_lock_opts="--exclude '.terraform.lock.hcl'"
 fi
 

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -24,3 +24,8 @@ else
     unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/
 fi
 /usr/bin/run-terraform "$@"
+
+if [[ -n "${USER_UID}" ]] && [[ -n "${USER_GID}" ]]; then
+    log-output info "Syncing pending changes back to user"
+    sudo rsync -qa --chown=${USER_UID}:${USER_GID} --exclude '.git/' --exclude '.terraform/'  ./ /src
+fi

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-multi-1.2
+multi-1.3


### PR DESCRIPTION
Adds a post-run sync back to the user's original mount. This will support an upcoming new feature that allows the write-back of Terraform dependency lock files
- Conditional to only trigger if the container is invoked using a suitable version of `platform-tools-terraform`
- `.terraform` directory excluded due to upcoming enabling of global plugin cache and to prevent excessive startup and shutdown times when dealing with codebases with many providers and/or modules (maintains current behaviour)
- Add new env var to allow handling of lock file to be disabled via `TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE`
- Added debug logging
- Removed UID check