### PR TITLE
Exclude ssh agent files

### DIFF
--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -28,7 +28,7 @@ rsync_aws_command="sudo rsync -qa /root/.aws /home/tfrunner/"
 log-output debug "Running rsync command: ${rsync_aws_command}"
 eval "${rsync_aws_command}"
 
-rsync_ssh_command="sudo rsync -qa /root/.ssh /home/tfrunner/"
+rsync_ssh_command="sudo rsync -qa /root/.ssh /home/tfrunner/ --exclude '/*/agent'"
 log-output debug "Running rsync command: ${rsync_ssh_command}"
 eval "${rsync_ssh_command}"
 

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-multi-1.3
+multi-1.4


### PR DESCRIPTION
Excludes the default SSH agent `agent/` subdirectory when performing the `rsync` operation against the mounted `.ssh` volume to avoid copying the user's SSH agent socket files.