### PR TITLE
Install proxy certificates at runtime, not build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM amazonlinux:2
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG IBOSS_ENDPOINT
 ARG JQ_VERSION="1.8.1"
 ARG PLATFORM_TOOLS_VERSION="1.0.18"
 ARG TARGETARCH
@@ -25,10 +24,6 @@ RUN yum update -y && \
         yum-utils-1.1.31 \
         zip-3.0 && \
     yum clean all
-
-RUN curl "http://192.168.60.37/websenseproxy_2025.cer" --output - 2>/dev/null | openssl x509 -inform pem -outform pem -out /etc/pki/ca-trust/source/anchors/websenseproxy.internal.ch.pem && \
-    curl -sL "${IBOSS_ENDPOINT}" > /etc/pki/ca-trust/source/anchors/iboss.pem && \
-    update-ca-trust
 
 WORKDIR /tmp
 

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -6,46 +6,81 @@ if [[ -z ${TF_RUNNER_VERSION} ]]; then
     TF_RUNNER_VERSION="0.12"
 fi
 
-TF_ARCHIVE=$(find ${TF_ROOT_PATH} -name "terraform_${TF_RUNNER_VERSION}*.zip" -print)
-if [[ ${TF_ARCHIVE} == "" ]]; then
-    log-output error "Unsupported terraform version: ${TF_RUNNER_VERSION}"
-    exit 1
-fi
+install_terraform_binary() {
+    log-output debug "Installing terraform binary"
+    TF_ARCHIVE=$(find ${TF_ROOT_PATH} -name "terraform_${TF_RUNNER_VERSION}*.zip" -print)
+    if [[ ${TF_ARCHIVE} == "" ]]; then
+        log-output error "Unsupported terraform version: ${TF_RUNNER_VERSION}"
+        exit 1
+    fi
 
-rsync_ignore_lock_opts=""
-if [[ -n "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" ]] && [[ "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" != "false" ]]; then
-    log-output debug "Excluding dependency lock file from rsync"
-    rsync_ignore_lock_opts="--exclude '.terraform.lock.hcl'"
-fi
+    unzip_command="sudo unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/ terraform"
+    log-output debug "Running unzip command: ${unzip_command}"
+    eval "${unzip_command}"
+}
 
-log-output info "Preparing terraform environment"
+prepare_terraform_environment() {
+    log-output info "Preparing terraform environment"
+    rsync_ignore_lock_opts=""
+    if [[ -n "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" ]] && [[ "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" != "false" ]]; then
+        log-output debug "Excluding dependency lock file from rsync"
+        rsync_ignore_lock_opts="--exclude '.terraform.lock.hcl'"
+    fi
 
-unzip_command="sudo unzip -q ${TF_ARCHIVE} -d ${TF_BIN_PATH}/ terraform"
-log-output debug "Running unzip command: ${unzip_command}"
-eval "${unzip_command}"
+    rsync_aws_command="sudo rsync -qa /root/.aws /home/tfrunner/"
+    log-output debug "Running rsync command: ${rsync_aws_command}"
+    eval "${rsync_aws_command}"
 
-rsync_aws_command="sudo rsync -qa /root/.aws /home/tfrunner/"
-log-output debug "Running rsync command: ${rsync_aws_command}"
-eval "${rsync_aws_command}"
+    rsync_ssh_command="sudo rsync -qa /root/.ssh /home/tfrunner/ --exclude '/*/agent'"
+    log-output debug "Running rsync command: ${rsync_ssh_command}"
+    eval "${rsync_ssh_command}"
 
-rsync_ssh_command="sudo rsync -qa /root/.ssh /home/tfrunner/ --exclude '/*/agent'"
-log-output debug "Running rsync command: ${rsync_ssh_command}"
-eval "${rsync_ssh_command}"
+    rsync_src_command="sudo rsync -qa --exclude '.terraform' ${rsync_ignore_lock_opts} /src /home/tfrunner/"
+    log-output debug "Running rsync command: ${rsync_src_command}"
+    eval "${rsync_src_command}"
 
-rsync_src_command="sudo rsync -qa --exclude '.terraform' ${rsync_ignore_lock_opts} /src /home/tfrunner/"
-log-output debug "Running rsync command: ${rsync_src_command}"
-eval "${rsync_src_command}"
+    sudo chown -R tfrunner:tfrunner /home/tfrunner/
+    pushd /home/tfrunner/src > /dev/null
+}
 
-sudo chown -R tfrunner:tfrunner /home/tfrunner/
-pushd /home/tfrunner/src > /dev/null
+install_proxy_certificates() {
+    log-output debug "Installing local proxy certificates"
+    local certs_installed; certs_installed=0
+    if [[ $(curl -s "https://node-cluster158354-swg.ibosscloud.com/certdirect" -o /dev/null -w "%{http_code}") -eq 200 ]]; then
+        log-output debug "Installing iBoss proxy certificate"
+        sudo curl -s "https://node-cluster158354-swg.ibosscloud.com/certdirect" -o /etc/pki/ca-trust/source/anchors/iboss.pem
+        certs_installed=1
+    fi
+
+    if [[ $(curl -s "http://192.168.60.37/websenseproxy_2025.cer" -o /dev/null -w "%{http_code}") -eq 200 ]]; then
+        log-output debug "Installing Websense proxy certificate"
+        sudo curl "http://192.168.60.37/websenseproxy_2025.cer" --output - 2>/dev/null | \
+            sudo openssl x509 -inform pem -outform pem -out /etc/pki/ca-trust/source/anchors/websenseproxy.pem
+        certs_installed=1
+    fi
+
+    if [[ $certs_installed -eq 1 ]]; then
+        log-output debug "Updating CA trust stores"
+        sudo update-ca-trust
+    fi
+}
+
+sync_changes() {
+    if [[ -z $TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE ]] || [[ "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" == "false" ]]; then
+        if [[ -n "${USER_UID}" ]] && [[ -n "${USER_GID}" ]]; then
+            rsync_sync_back_command="sudo rsync -qa --chown=${USER_UID}:${USER_GID} --exclude '.git/' --exclude '.terraform/'  ./ /src"
+            log-output info "Syncing pending changes back to user"
+            eval "${rsync_sync_back_command}"
+        fi
+    fi
+}
+
+# Main
+install_terraform_binary
+prepare_terraform_environment
+install_proxy_certificates
 
 log-output debug "Passing operation to run-terraform"
-/usr/bin/run-terraform "$@"
+/usr/bin/run-terraform "$@" || true
 
-if [[ -z $TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE ]] || [[ "${TF_RUNNER_IGNORE_DEPENDENCY_LOCK_FILE}" == "false" ]]; then
-    if [[ -n "${USER_UID}" ]] && [[ -n "${USER_GID}" ]]; then
-        rsync_sync_back_command="sudo rsync -qa --chown=${USER_UID}:${USER_GID} --exclude '.git/' --exclude '.terraform/'  ./ /src"
-        log-output info "Syncing pending changes back to user"
-        eval "${rsync_sync_back_command}"
-    fi
-fi
+sync_changes


### PR DESCRIPTION
Updates certificate handling to no longer install certificates at build time. Appropriate proxy certificates will now be selectively installed at runtime.

Currently supporting:
- Legacy websense
- iBoss
