### PR TITLE
Bump platform-tools Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM amazonlinux:2
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG JQ_VERSION="1.8.1"
-ARG PLATFORM_TOOLS_VERSION="1.0.18"
+ARG PLATFORM_TOOLS_VERSION="1.1.0"
 ARG TARGETARCH
 ARG TF_VERSIONS="0.12 0.13 1.3 1.9 1.14"
 ARG TF_ROOT_PATH="/terraform"

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-multi-1.4
+multi-1.5


### PR DESCRIPTION
Bumps platform-tools version to `1.1.0`
This brings in the full support for Terraform dependency lock files